### PR TITLE
Fixes import error from upstream change.

### DIFF
--- a/sphinxext/remoteliteralinclude.py
+++ b/sphinxext/remoteliteralinclude.py
@@ -10,7 +10,6 @@ from docutils.statemachine import ViewList
 from six import text_type
 
 from sphinx import addnodes
-from sphinx.deprecation import RemovedInSphinx40Warning
 from sphinx.locale import __
 from sphinx.util import logging
 from sphinx.util import parselinenos


### PR DESCRIPTION
Removes the class import that has been removed from Sphinx in PR https://github.com/sphinx-doc/sphinx/pull/9263.

Tested a successful build [here](https://app.travis-ci.com/github/H0R5E/WEC-Sim/builds/232629582) with results at the end of [this section](https://h0r5e.github.io/WEC-Sim/master/man/advanced_features.html#nonlinear-buoyancy-and-froude-krylov-wave-excitation-tutorial-heaving-ellipsoid).

Fixes #14 