### PR TITLE
Add retry logic for failed requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ then in your ``conf.py`` under ``extensions``, it should look like the following
 extensions = ["sphinxext.remoteliteralinclude"]
 ```
 
+## Configuration
+
+There are two optional configuration for retry logic for failed requests.
+
+```python
+remoteliteralinclude_retry_time = 1.0
+remoteliteralinclude_max_retry_time = 180.0
+```
+
+The retry_time is the base time in seconds to wait, with an exponential backoff until max_retry_time (in seconds) is reached.
+
 ## Usage
 
 Simply just use it as you normally would a normal ``literalinclude``

--- a/sphinxext/remoteliteralinclude.py
+++ b/sphinxext/remoteliteralinclude.py
@@ -60,10 +60,10 @@ class RemoteLiteralIncludeReader(object):
     def read_file(self, url, location=None):
         # type: (unicode, Any) -> List[unicode]
         max_retry_time = self.options.get(
-            "max_retry_time", self.config.remoteliteralinclude_max_retry_time
+            "remoteliteralinclude_max_retry_time", self.config.remoteliteralinclude_max_retry_time
         )
         base_retry_time = self.options.get(
-            "retry_time", self.config.remoteliteralinclude_retry_time
+            "remoteliteralinclude_retry_time", self.config.remoteliteralinclude_retry_time
         )
 
         total_time = 0  # Track total retry time

--- a/sphinxext/remoteliteralinclude.py
+++ b/sphinxext/remoteliteralinclude.py
@@ -1,7 +1,5 @@
-import codecs
+import time
 import requests
-import sys
-import warnings
 
 from difflib import unified_diff
 
@@ -47,6 +45,7 @@ class RemoteLiteralIncludeReader(object):
         self.options = options
         self.encoding = options.get("encoding", config.source_encoding)
         self.lineno_start = self.options.get("lineno-start", 1)
+        self.config = config
 
         self.parse_options()
 
@@ -60,29 +59,54 @@ class RemoteLiteralIncludeReader(object):
 
     def read_file(self, url, location=None):
         # type: (unicode, Any) -> List[unicode]
-        # try:
-        # with codecs.open(url, 'r', self.encoding, errors='strict') as f:  # type: ignore  # NOQA
-        #     text = f.read()  # type: unicode
-        response = requests.get(
-            url, headers={"User-Agent": "sphinxext-remoteliteralinclude"}
+        max_retry_time = self.options.get(
+            "max_retry_time", self.config.remoteliteralinclude_max_retry_time
         )
-        text = response.text
+        base_retry_time = self.options.get(
+            "retry_time", self.config.remoteliteralinclude_retry_time
+        )
 
-        if text:
+        total_time = 0  # Track total retry time
+        attempt = 0
+
+        while total_time < max_retry_time:
+            response = requests.get(
+                url, headers={"User-Agent": "sphinxext-remoteliteralinclude"}
+            )
+
+            if response.status_code in [408, 429, 500, 502, 503, 504]:
+                retry_time = base_retry_time * (2**attempt)  # Exponential backoff
+                if total_time + retry_time < max_retry_time:
+                    print(
+                        f"Received status code {response.status_code}. Retrying in {retry_time} seconds for url: {url}..."
+                    )
+                    time.sleep(retry_time)
+                    total_time += retry_time
+                    attempt += 1
+                    continue
+                else:
+                    print(
+                        f"Max retry time of {max_retry_time} reached. Status code: {response.status_code} for url: {url}"
+                    )
+                    response.raise_for_status()
+
             response.raise_for_status()
 
-            if "tab-width" in self.options:
-                text = text.expandtabs(self.options["tab-width"])
+            text = response.text
+            if text:
+                if "tab-width" in self.options:
+                    text = text.expandtabs(self.options["tab-width"])
 
-            return text.splitlines(True)
-        else:
-            raise IOError(__("Include file %r not found or reading it failed") % url)
-        # except (IOError, OSError):
-        #     raise IOError(__('Include file %r not found or reading it failed') % url)
-        # except UnicodeError:
-        #     raise UnicodeError(__('Encoding %r used for reading included file %r seems to '
-        #                           'be wrong, try giving an :encoding: option') %
-        #                        (self.encoding, url))
+                return text.splitlines(True)
+            else:
+                raise IOError(
+                    __("Include file %r not found or reading it failed") % url
+                )
+
+        print(
+            f"Max retry time of {max_retry_time} reached. Status code: {response.status_code} for url: {url}"
+        )
+        response.raise_for_status()
 
     def read(self, location=None):
         # type: (Any) -> Tuple[unicode, int]
@@ -349,6 +373,9 @@ class RemoteLiteralInclude(SphinxDirective):
 def setup(app):
     directives.register_directive("rli", RemoteLiteralInclude)
     directives.register_directive("remoteliteralinclude", RemoteLiteralInclude)
+
+    app.add_config_value("remoteliteralinclude_max_retry_time", 180.0, "env")
+    app.add_config_value("remoteliteralinclude_retry_time", 1.0, "env")
 
     return {
         "parallel_read_safe": True,

--- a/sphinxext/remoteliteralinclude.py
+++ b/sphinxext/remoteliteralinclude.py
@@ -60,10 +60,12 @@ class RemoteLiteralIncludeReader(object):
     def read_file(self, url, location=None):
         # type: (unicode, Any) -> List[unicode]
         max_retry_time = self.options.get(
-            "remoteliteralinclude_max_retry_time", self.config.remoteliteralinclude_max_retry_time
+            "remoteliteralinclude_max_retry_time",
+            self.config.remoteliteralinclude_max_retry_time,
         )
         base_retry_time = self.options.get(
-            "remoteliteralinclude_retry_time", self.config.remoteliteralinclude_retry_time
+            "remoteliteralinclude_retry_time",
+            self.config.remoteliteralinclude_retry_time,
         )
 
         total_time = 0  # Track total retry time

--- a/sphinxext/remoteliteralinclude.py
+++ b/sphinxext/remoteliteralinclude.py
@@ -60,12 +60,10 @@ class RemoteLiteralIncludeReader(object):
     def read_file(self, url, location=None):
         # type: (unicode, Any) -> List[unicode]
         max_retry_time = self.options.get(
-            "remoteliteralinclude_max_retry_time",
-            self.config.remoteliteralinclude_max_retry_time,
+            "max_retry_time", self.config.remoteliteralinclude_max_retry_time
         )
         base_retry_time = self.options.get(
-            "remoteliteralinclude_retry_time",
-            self.config.remoteliteralinclude_retry_time,
+            "retry_time", self.config.remoteliteralinclude_retry_time
         )
 
         total_time = 0  # Track total retry time

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -6,13 +6,7 @@ from sphinx.config import Config
 from sphinxext.remoteliteralinclude import RemoteLiteralIncludeReader
 
 
-DUMMY_CONFIG = Config(
-    {
-        "remoteliteralinclude_max_retry_time": 5,
-        "remoteliteralinclude_retry_time": 1,
-    },
-    {},
-)
+DUMMY_CONFIG = Config({}, {})
 
 
 @pytest.mark.sphinx("html", testroot="simple-short")
@@ -41,6 +35,8 @@ def test_pyobject():
     url = "https://raw.githubusercontent.com/wpilibsuite/sphinxext-remoteliteralinclude/main/sphinxext/remoteliteralinclude.py"
     # Grab the entire RemoteLiteralIncludeReader.__init__
     options = {"pyobject": "RemoteLiteralIncludeReader.__init__"}
+    DUMMY_CONFIG.add("remoteliteralinclude_max_retry_time", 5.0, "env", float)
+    DUMMY_CONFIG.add("remoteliteralinclude_retry_time", 1.0, "env", float)
     reader = RemoteLiteralIncludeReader(url, options, DUMMY_CONFIG)
     content, lines = reader.read()
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -6,7 +6,13 @@ from sphinx.config import Config
 from sphinxext.remoteliteralinclude import RemoteLiteralIncludeReader
 
 
-DUMMY_CONFIG = Config({}, {})
+DUMMY_CONFIG = Config(
+    {
+        "remoteliteralinclude_max_retry_time": 5,
+        "remoteliteralinclude_retry_time": 1,
+    },
+    {},
+)
 
 
 @pytest.mark.sphinx("html", testroot="simple-short")


### PR DESCRIPTION
Needed because of the github rate limits for any request: https://github.blog/changelog/2025-05-08-updated-rate-limits-for-unauthenticated-requests/ 
It does an exponential backoff of retries (default 1 second) up until a maximum retry time (default 180 second). 1 second looks to be sufficient for github.